### PR TITLE
Add AI Models Catalog — 118 audio input + 34 audio output models

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,9 @@ If you find the listing and survey useful for your work, please cite the paper:
   year={2023}
 }
 ```
+
+
+## AI Model Catalogs
+
+- [AI Models Catalog](https://github.com/i-need-token/ai-models) - Structured catalog of 4,587+ AI models across 95 providers. Includes 118 audio input models and 34 audio output models with pricing and capabilities. Interactive catalog: https://i-need-token.github.io/ai-models/
+


### PR DESCRIPTION
## Addition

- **Name:** AI Models Catalog
- **URL:** https://github.com/i-need-token/ai-models

## Description

Structured catalog of 4,587+ AI models across 95 providers. Includes 118 audio input models and 34 audio output models with pricing, context windows, and capabilities — useful for selecting audio models for speech recognition, synthesis, and translation tasks.

## Why this belongs

- **Audio model coverage**: 118 audio input + 34 audio output models with detailed metadata
- **First-party data**: All data sourced from provider APIs and official documentation
- **Interactive catalog**: https://i-need-token.github.io/ai-models/
- **Open source**: MIT licensed with automated scraping pipeline