### PR TITLE
Add FunAudioLLM to large audio models

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ A curated list of awesome large AI models in audio signal processing, inspired b
 **MusicLM: Generating Music From Text** [2023].<br>*Andrea Agostinelli, Timo I. Denk, Zalán Borsos, Jesse Engel, Mauro Verzetti, Antoine Caillon, Qingqing Huang, Aren Jansen, Adam Roberts, Marco Tagliasacchi, Matt Sharifi, Neil Zeghidour, Christian Frank*<br>[[PDF](https://arxiv.org/abs/2301.11325)]<br>
 **SeamlessM4T—Massively Multilingual & Multimodal Machine Translation** [2023].<br>*Seamless Communication, Loic Barrault, Andy Chung, David Dale, Ning Dong (AI), Paul-Ambroise Duquenne, Hady Elsahar et. al.*<br>[[PDF](https://ai.meta.com/research/publications/seamless-m4t/)]<br>
 **SALMONN: Towards Generic Hearing Abilities for Large Language Models** [2023].<br>*Changli Tang, Wenyi Yu, Guangzhi Sun, Xiaozhao Chen, Tian Tan, Wei Li, Lu Lu, Zejun Ma, Chao Zhang*<br>[[PDF](https://arxiv.org/abs/2310.13289)][[Github](https://github.com/bytedance/SALMONN)]<br>
+**FunAudioLLM: Voice Understanding and Generation Foundation Models for Natural Interaction Between Humans and LLMs** [2024].<br>*Keyu An et al.*<br>[[PDF](https://arxiv.org/abs/2407.04051)][[Github](https://github.com/FunAudioLLM/SenseVoice)]<br>
 <br>
 
 ## Automatic Speech Recognition (ASR)


### PR DESCRIPTION
## Summary

- Add FunAudioLLM to the Popular Large Audio Models section.
- Link the arXiv paper and the SenseVoice official code repository.

## Validation

- Confirmed the FunAudioLLM and SenseVoice links are unique in the README.
- Verified `git diff --check` passes.
- Verified the added arXiv and GitHub links return HTTP 200.
