### PR TITLE
Add FunAudioLLM and Fun-ASR papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,12 @@ A curated list of awesome large AI models in audio signal processing, inspired b
 **MusicLM: Generating Music From Text** [2023].<br>*Andrea Agostinelli, Timo I. Denk, Zalán Borsos, Jesse Engel, Mauro Verzetti, Antoine Caillon, Qingqing Huang, Aren Jansen, Adam Roberts, Marco Tagliasacchi, Matt Sharifi, Neil Zeghidour, Christian Frank*<br>[[PDF](https://arxiv.org/abs/2301.11325)]<br>
 **SeamlessM4T—Massively Multilingual & Multimodal Machine Translation** [2023].<br>*Seamless Communication, Loic Barrault, Andy Chung, David Dale, Ning Dong (AI), Paul-Ambroise Duquenne, Hady Elsahar et. al.*<br>[[PDF](https://ai.meta.com/research/publications/seamless-m4t/)]<br>
 **SALMONN: Towards Generic Hearing Abilities for Large Language Models** [2023].<br>*Changli Tang, Wenyi Yu, Guangzhi Sun, Xiaozhao Chen, Tian Tan, Wei Li, Lu Lu, Zejun Ma, Chao Zhang*<br>[[PDF](https://arxiv.org/abs/2310.13289)][[Github](https://github.com/bytedance/SALMONN)]<br>
+**FunAudioLLM: Voice Understanding and Generation Foundation Models for Natural Interaction Between Humans and LLMs** [2024].<br>*Keyu An et al.*<br>[[PDF](https://arxiv.org/abs/2407.04051)][[Github](https://github.com/FunAudioLLM)]<br>
 <br>
 
 ## Automatic Speech Recognition (ASR)
 
+**Fun-ASR Technical Report** [2025].<br>*Keyu An et al.*<br>[[PDF](https://arxiv.org/abs/2509.12508)][[Github](https://github.com/FunAudioLLM/Fun-ASR)]<br>
 **On decoder-only architecture for speech-to-text and large language model integration** [2023].<br>*Jian Wu, Yashesh Gaur, Zhuo Chen, Long Zhou, Yimeng Zhu, Tianrui Wang, Jinyu Li, Shujie Liu, Bo Ren, Linquan Liu, Yu Wu*<br>[[PDF](https://arxiv.org/abs/2307.03917)]<br>
 **X-LLM: Bootstrapping Advanced Large Language Models by Treating Multi-Modalities as Foreign Languages** [2023].<br>*Feilong Chen, Minglun Han, Haozhi Zhao, Qingyang Zhang, Jing Shi, Shuang Xu, Bo Xu*<br>[[PDF](https://arxiv.org/abs/2305.04160)][[Github](https://github.com/phellonchen/X-LLM)]<br>
 **Adapting Large Language Model with Speech for Fully Formatted End-to-End Speech Recognition** [2023].<br>*Shaoshi Ling, Yuxuan Hu, Shuangbei Qian, Guoli Ye, Yao Qian, Yifan Gong, Ed Lin, Michael Zeng*<br>[[PDF](https://arxiv.org/abs/2307.08234)]<br>


### PR DESCRIPTION
## Summary

Adds two recent FunAudioLLM/Fun-ASR resources to the list:

- `FunAudioLLM: Voice Understanding and Generation Foundation Models for Natural Interaction Between Humans and LLMs` under Popular Large Audio Models
- `Fun-ASR Technical Report` under Automatic Speech Recognition (ASR)

Both entries include arXiv and GitHub links, matching the existing README format.

## Validation

- `git diff --check`
- confirmed both new entries appear in `README.md`
- checked the four added links return HTTP 200:
  - `https://arxiv.org/abs/2407.04051`
  - `https://github.com/FunAudioLLM`
  - `https://arxiv.org/abs/2509.12508`
  - `https://github.com/FunAudioLLM/Fun-ASR`
