### PR TITLE
Add 'Audio Reasoning and Reinforcement Learning' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A curated list of awesome large AI models in audio signal processing, inspired b
 - [Neural Speech Synthesis](#neural-speech-synthesis)
 - [Speech Translation (ST)](#speech-translation-st)
 - [Other Speech Applications](#other-speech-applications)
+- [Audio Reasoning and Reinforcement Learning](#audio-reasoning-and-reinforcement-learning)
 - [Large Audio Models in Music](#large-audio-models-in-music)
 - [Audio Datasets](#audio-datasets)
 
@@ -114,6 +115,17 @@ A curated list of awesome large AI models in audio signal processing, inspired b
 **SALMONN: Towards Generic Hearing Abilities for Large Language Models** [2023].<br>*Changli Tang, Wenyi Yu, Guangzhi Sun, Xiaozhao Chen, Tian Tan, Wei Li, Lu Lu, Zejun Ma, Chao Zhang*<br>[[PDF](https://arxiv.org/abs/2310.13289)][[Github](https://github.com/bytedance/SALMONN)]<br>
 - [StoryRoute](https://storyroute.netlify.app) - GPS-triggered LLM story generation synthesized via a large TTS model into real-time audio narration as users walk through any city<br>
 - [AnveVoice](https://anvevoice.app) - Voice AI for real-time website interaction using audio models. Sub-700ms STT-to-action, 50+ languages, real DOM actions. MIT-0 license.
+<br>
+
+## Audio Reasoning and Reinforcement Learning
+
+**Reinforcement Learning with Evolving Rubrics as Rewards for Audio Reasoning** [2026].<br>*Fangxu Yu, Tao Feng, Dehai Min, Zinan Lin, Weijia Xu, Michael Xu, Philip S. Yu, Ge Liu, Tianyi Zhou*<br>[[PDF](https://arxiv.org/abs/2608.02831)][[Project](https://audiorubrics.github.io)]<br>
+**SoundMind: RL-Incentivized Logic Reasoning for Audio-Language Models** [2025].<br>*Xingjian Diao, Chunhui Zhang, Keyi Kong, Weiyi Wu, Chiyu Ma, Zhongyu Ouyang, Peijun Qing, Soroush Vosoughi, Jiang Gui*<br>[[PDF](https://arxiv.org/abs/2506.12935)][[Github](https://github.com/xid32/SoundMind)]<br>
+**Omni-R1: Do You Really Need Audio to Fine-Tune Your Audio LLM?** [2025].<br>*Andrew Rouditchenko, Saurabhchand Bhati, Edson Araujo, Samuel Thomas, Hilde Kuehne, Rogerio Feris, James Glass*<br>[[PDF](https://arxiv.org/abs/2505.09439)]<br>
+**EchoInk-R1: Exploring Audio-Visual Reasoning in Multimodal LLMs via Reinforcement Learning** [2025].<br>*Zhenghao Xing, Xiaowei Hu, Chi-Wing Fu, Wenhai Wang, Jifeng Dai, Pheng-Ann Heng*<br>[[PDF](https://arxiv.org/abs/2505.04623)][[Github](https://github.com/HarryHsing/EchoInk)]<br>
+**SARI: Structured Audio Reasoning via Curriculum-Guided Reinforcement Learning** [2025].<br>*Cheng Wen, Tingwei Guo, Shuaijiang Zhao, Wei Zou, Xiangang Li*<br>[[PDF](https://arxiv.org/abs/2504.15900)]<br>
+**Reinforcement Learning Outperforms Supervised Fine-Tuning: A Case Study on Audio Question Answering** [2025].<br>*Gang Li, Jizhong Liu, Heinrich Dinkel, Yadong Niu, Junbo Zhang, Jian Luan*<br>[[PDF](https://arxiv.org/abs/2503.11197)][[Github](https://github.com/xiaomi-research/r1-aqa)]<br>
+**Audio-Reasoner: Improving Reasoning Capability in Large Audio Language Models** [2025].<br>*Zhifei Xie, Mingbao Lin, Zihang Liu, Pengcheng Wu, Shuicheng Yan, Chunyan Miao*<br>[[PDF](https://arxiv.org/abs/2503.02318)][[Github](https://github.com/xzf-thu/Audio-Reasoner)]<br>
 <br>
 
 ## Large Audio Models in Music


### PR DESCRIPTION
Thanks for maintaining this list. I noticed it has no home for a line of work that has grown quickly since the survey was written: **applying reinforcement learning to reasoning in large audio models**. R1-style post-training arrived in the audio domain in early 2025 and there are now a number of well-cited papers with released code, none of which fit under ASR, Synthesis, Speech Translation, or Music.

This PR adds an **Audio Reasoning and Reinforcement Learning** section with seven papers, plus the corresponding Overview entry.

### Papers added

| Paper | Contribution |
|---|---|
| [AudioRubrics](https://arxiv.org/abs/2608.02831) (2026) | Self-evolving, audio-grounded rubrics as RL rewards |
| [SoundMind](https://arxiv.org/abs/2506.12935) (2025) | RL-incentivized logic reasoning for audio-language models |
| [Omni-R1](https://arxiv.org/abs/2505.09439) (2025) | Analyzes how much audio actually matters when fine-tuning audio LLMs |
| [EchoInk-R1](https://arxiv.org/abs/2505.04623) (2025) | Audio-visual reasoning via RL |
| [SARI](https://arxiv.org/abs/2504.15900) (2025) | Curriculum-guided RL for structured audio reasoning |
| [R1-AQA](https://arxiv.org/abs/2503.11197) (2025) | RL vs. SFT on audio question answering |
| [Audio-Reasoner](https://arxiv.org/abs/2503.02318) (2025) | Chain-of-thought reasoning for large audio language models |

### Notes on the entries

- Formatted exactly like existing entries: `**Title** [YEAR].<br>*Authors*<br>[[PDF]][[Github]]<br>`
- Author lists and titles were pulled from the arXiv API rather than transcribed, so they should match the published metadata
- Every `[[Github]]` link was checked to resolve; papers without a verified repo have a PDF link only
- Section placed after *Other Speech Applications* and before *Music*, and added to the Overview index
- Sorted newest first

### Disclosure

I am an author of the AudioRubrics paper, which is what prompted me to look at this list. I have seeded the section with the other six papers so it stands on its own as a category rather than as a single-entry addition. Happy to drop my own paper, reorder, or rename the section if you would rather shape it differently.